### PR TITLE
Add HTML metadata via Marp CLI v0.5.0

### DIFF
--- a/PITCHME.md
+++ b/PITCHME.md
@@ -1,4 +1,7 @@
 ---
+title: Marp CLI example
+descrption: Marp CLI + Netlify ≒ GitPitch style hosting of Marp slide deck on the web
+image: https://user-images.githubusercontent.com/3993388/52071974-70a39880-25c7-11e9-8aee-9e026fc7f49e.png
 theme: uncover
 paginate: true
 _paginate: false
@@ -20,6 +23,7 @@ _color: #fff
 -->
 
 ##### <!--fit--> [@marp-team/marp-cli](https://github.com/marp-team/marp-cli) + [Netlify](https://www.netlify.com/)
+
 ##### <!--fit--> ≒ [GitPitch](https://gitpitch.com/) style hosting
 
 ---

--- a/marp.config.js
+++ b/marp.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  output: 'dist/index.html',
+  url: process.env.URL,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "@marp-team/marp-cli": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-0.4.0.tgz",
-      "integrity": "sha512-E5kWuCbviUlVCJDbx3Jqr46/+3Fmi/mwdpV4vONlFzvfMiZDMwwY1GbrHZTs0K79WPfSvWpp1UnIlJlJGkujeA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-0.5.0.tgz",
+      "integrity": "sha512-u/cjpCZjbvJtPSqYpTzkZy63LWm5qeaZ7j0J1ZlQ5Vo1jdilh6lud/+MFufszcE2wpNQ1a7cANC57rnJdm/+UQ==",
       "dev": true,
       "requires": {
-        "@marp-team/marp-core": "^0.5.1",
-        "@marp-team/marpit": "^0.6.1",
+        "@marp-team/marp-core": "^0.5.2",
+        "@marp-team/marpit": "^0.7.0",
         "carlo": "^0.9.43",
         "chalk": "^2.4.2",
         "chokidar": "^2.0.4",
@@ -35,15 +35,15 @@
       }
     },
     "@marp-team/marp-core": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-0.5.1.tgz",
-      "integrity": "sha512-kR4B4DS091IaXJ14jMu+saEKmv+9V63A52iA9Yown5oZSUcytIBVBUuhsQ0IdO6DZ03rkhp4djoHq+lXD0ScDQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-0.5.2.tgz",
+      "integrity": "sha512-SgPX9GcSFqdRzbUvmbiwjv1529RysUsni9iwxCVbhwQXGUFcLRzRxjpGgu0GP3QTh14gZuJjc+px5mouGEKiVg==",
       "dev": true,
       "requires": {
-        "@marp-team/marpit": "^0.6.1",
+        "@marp-team/marpit": "^0.7.0",
         "@marp-team/marpit-svg-polyfill": "^0.2.0",
         "emoji-regex": "^7.0.3",
-        "highlight.js": "^9.13.1",
+        "highlight.js": "^9.14.1",
         "katex": "^0.10.0",
         "markdown-it": "^8.4.2",
         "markdown-it-emoji": "^1.4.0",
@@ -53,9 +53,9 @@
       }
     },
     "@marp-team/marpit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@marp-team/marpit/-/marpit-0.6.1.tgz",
-      "integrity": "sha512-LeYb+18GjpXm0ffWcs6nuE5nxDESNR+dcUTVUcCxr+c8qCGIy/NupB+6j1jui3uEZqg4ZGqCm7qdbBnlySm0lw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@marp-team/marpit/-/marpit-0.7.0.tgz",
+      "integrity": "sha512-j1kNhvyZjsdV4UpO+DtcHSPiVgtNx03BP+hiYXsiTbzFAL641FSBt70QngT1nvWXmglERbp/izVcC9excbkgZQ==",
       "dev": true,
       "requires": {
         "color-string": "^1.5.3",
@@ -63,7 +63,7 @@
         "lodash.kebabcase": "^4.1.1",
         "markdown-it": "^8.4.2",
         "markdown-it-front-matter": "^0.1.2",
-        "postcss": "^7.0.13"
+        "postcss": "^7.0.14"
       }
     },
     "@marp-team/marpit-svg-polyfill": {
@@ -1921,9 +1921,9 @@
       }
     },
     "highlight.js": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+      "version": "9.14.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.14.1.tgz",
+      "integrity": "sha512-UpSrdhp5jHPbrf9+/bE1p8kxZlh9QHWD24zp2jMxCP1Po9be7XH7GiK5Q00OvCBlji1FVa+nTYOkZqrBE1pcHw==",
       "dev": true
     },
     "http-errors": {
@@ -2371,14 +2371,14 @@
       "dev": true
     },
     "mem": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-      "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
       "dev": true,
       "requires": {
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^1.0.0",
-        "p-is-promise": "^1.1.0"
+        "p-is-promise": "^2.0.0"
       }
     },
     "merge-descriptors": {
@@ -2657,9 +2657,9 @@
       "dev": true
     },
     "p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
       "dev": true
     },
     "p-limit": {
@@ -3541,9 +3541,9 @@
       "dev": true
     },
     "uc.micro": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,5 @@
   },
   "devDependencies": {
     "@marp-team/marp-cli": "^0.5.0"
-  },
-  "marp": {
-    "output": "dist/index.html"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "marp -ps ."
   },
   "devDependencies": {
-    "@marp-team/marp-cli": "^0.4.0"
+    "@marp-team/marp-cli": "^0.5.0"
   },
   "marp": {
     "output": "dist/index.html"


### PR DESCRIPTION
Use HTML metadata via Markdown and Netlify build environment variable by upgrading [Marp CLI v0.5.0](https://github.com/marp-team/marp-cli/releases/v0.5.0).