### PR TITLE
Autogen Open Graph image

### DIFF
--- a/.puppeteer.js
+++ b/.puppeteer.js
@@ -1,0 +1,2 @@
+// Output installed Chromium path by puppeteer
+console.log(require('puppeteer').executablePath())

--- a/PITCHME.md
+++ b/PITCHME.md
@@ -1,7 +1,6 @@
 ---
 title: Marp CLI example
 description: Marp CLI + Netlify ≒ GitPitch style hosting of Marp slide deck on the web
-image: https://user-images.githubusercontent.com/3993388/52071974-70a39880-25c7-11e9-8aee-9e026fc7f49e.png
 theme: uncover
 paginate: true
 _paginate: false

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ It's surprisingly easy to start writing your slide deck! Push **"Deploy to netli
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/yhatt/marp-cli-example)
 
-After than, clone *your repository* and install Marp CLI. (Required [Node.js](https://nodejs.org/) >= 8)
+After than, clone _your repository_ and install Marp CLI. (Required [Node.js](https://nodejs.org/) >= 8)
 
-```
+```bash
 git clone https://github.com/[your-name]/[repository-name].git
 npm install
 ```
@@ -30,19 +30,26 @@ Please see the documentation of [Marpit Markdown](https://marpit.marp.app/markdo
 
 ### Preview deck
 
-```
+```bash
 npm run start
 ```
 
 It will be opened preview window, and track change of `PITCHME.md`.
 
-### Convert into static HTML
+### Build deck
 
-```
+```bash
 npm run build
 ```
 
-The converted HTML will output to `dist/index.html`.
+The built assets will output to `dist` folder.
+
+#### Build per assets
+
+```bash
+npm run deck      # Output static HTML to dist/index.html
+npm run og-image  # Output image for Open Graph to dist/og-image.jpg
+```
 
 ## LICENSE
 

--- a/marp.config.js
+++ b/marp.config.js
@@ -1,4 +1,3 @@
 module.exports = {
-  output: 'dist/index.html',
   url: process.env.URL,
 }

--- a/marp.config.js
+++ b/marp.config.js
@@ -1,3 +1,4 @@
 module.exports = {
+  ogImage: process.env.URL && `${process.env.URL}/og-image.jpg`,
   url: process.env.URL,
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "dist"
-  command = "npm i puppeteer && npm run build"
+  command = "npm i puppeteer && CHROME_PATH=$(node .puppeteer.js) npm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "dist"
-  command = "npm run build"
+  command = "npm i puppeteer && npm run build"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@marp-team/marp-cli": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-0.5.0.tgz",
-      "integrity": "sha512-u/cjpCZjbvJtPSqYpTzkZy63LWm5qeaZ7j0J1ZlQ5Vo1jdilh6lud/+MFufszcE2wpNQ1a7cANC57rnJdm/+UQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-0.6.0.tgz",
+      "integrity": "sha512-H4DQTBmoIdJMsJgPVAC1yGw5IUkHv2kKCsqRdAlHoP4dQLM2cN5NyzioiwJfFFqBinHKvDs6fIiB1CJhH0LgPA==",
       "dev": true,
       "requires": {
         "@marp-team/marp-core": "^0.5.2",
@@ -26,7 +26,7 @@
         "os-locale": "^3.1.0",
         "pkg-up": "^2.0.0",
         "portfinder": "^1.0.20",
-        "puppeteer-core": "^1.11.0",
+        "puppeteer-core": "^1.12.1",
         "serve-index": "^1.9.1",
         "terminate": "^2.1.2",
         "tmp": "^0.0.33",
@@ -1921,9 +1921,9 @@
       }
     },
     "highlight.js": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.14.1.tgz",
-      "integrity": "sha512-UpSrdhp5jHPbrf9+/bE1p8kxZlh9QHWD24zp2jMxCP1Po9be7XH7GiK5Q00OvCBlji1FVa+nTYOkZqrBE1pcHw==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.14.2.tgz",
+      "integrity": "sha512-Nc6YNECYpxyJABGYJAyw7dBAYbXEuIzwzkqoJnwbc1nIpCiN+3ioYf0XrBnLiyyG0JLuJhpPtt2iTSbXiKLoyA==",
       "dev": true
     },
     "http-errors": {
@@ -2878,9 +2878,9 @@
       }
     },
     "puppeteer-core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-1.11.0.tgz",
-      "integrity": "sha512-JTsJKCQdrk1RqEGZN3l2TyW7Rhy7GWRRzd3PftYyA3B35l0t0lLU+gdF7czemnpSVVMiAgHpM1Uk/iO6jLreMA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-1.12.1.tgz",
+      "integrity": "sha512-arGXPRe1dkX3+tOh1GMQ0Ny3CoOCRurkHAW4AZEBIBMX/LdY6ReFqRTT9YSV3d9zzxiIat9kJc3v9h9nkxAu3g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -3519,9 +3519,9 @@
       }
     },
     "twemoji": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-11.2.0.tgz",
-      "integrity": "sha512-DgTadXkRHugun6mjUf1k3ni04WC4jHOX1bN5MjuCM3nwRyIMdXIr8FmWzW5mEIZjht5jD3NaEyXC4j3POdQwyQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-11.3.0.tgz",
+      "integrity": "sha512-xN/vlR6+gDmfjt6LInAqwGAv3Agwrmzx5TD1jEFwKS19IOGDrX0/3OB8GP1wUYPVIdkaer5hw6qd+52jzvz0Lg==",
       "dev": true
     },
     "type-is": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "license": "WTFPL",
   "private": true,
   "scripts": {
-    "build": "marp PITCHME.md",
+    "build": "marp PITCHME.md -o dist/index.html",
     "start": "marp -ps ."
   },
   "devDependencies": {
-    "@marp-team/marp-cli": "^0.5.0"
+    "@marp-team/marp-cli": "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "WTFPL",
   "private": true,
   "scripts": {
-    "build": "marp PITCHME.md -o dist/index.html",
+    "build": "npm run -s og-image && npm run -s deck",
+    "deck": "marp PITCHME.md -o dist/index.html",
+    "og-image": "marp PITCHME.md -o dist/og-image.jpg",
     "start": "marp -ps ."
   },
   "devDependencies": {


### PR DESCRIPTION
[Marp CLI v0.6.0](https://github.com/marp-team/marp-cli/releases/v0.6.0) has supported `--image` option to make the first slide convertible into image. I updated build setting to generate `og:image` automatically. You have no longer to upload screenshot manually.

https://5c5517c131e3a70009820ae7--yhatt-marp-cli-example.netlify.com/og-image.jpg