### PR TITLE
Add settings for Marp for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["marp-team.marp-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+// Please add paths to enable custom themes in Markdown preview for VS Code
+// extension.
+// https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode
+{
+  "markdown.marp.themes": ["./themes/example.css"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
-// Please add paths to enable custom themes in Markdown preview for VS Code
-// extension.
+// Add paths to enable custom themes in Markdown preview for VS Code extension.
 // https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode
 {
   "markdown.marp.themes": ["./themes/example.css"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ Of course, you can manage deck via Git / GitHub at a forked repository. As same 
 
 Please see the documentation of [Marpit Markdown](https://marpit.marp.app/markdown), [the features of Marp Core](https://github.com/marp-team/marp-core#features), and the default example in [`PITCHME.md`](https://raw.githubusercontent.com/yhatt/marp-cli-example/master/PITCHME.md).
 
+[**Marp for VS Code**](https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode) extension is the best partner for writing Marp slide deck with live preview.
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode">
+    <img src="https://raw.githubusercontent.com/marp-team/marp-vscode/master/images/screenshot.png" width="500" />
+  </a>
+</p>
+
 ### Assets and themes
 
 - `assets` directory can put your assets for using in the deck. (e.g. Image resources)

--- a/themes/example.css
+++ b/themes/example.css
@@ -1,3 +1,8 @@
 /* @theme example */
 
 @import 'uncover';
+
+section {
+  background: #cef;
+  color: #135;
+}


### PR DESCRIPTION
[Marp for VS Code](https://github.com/marp-team/marp-vscode) 0.8.0 came to be able to use custom theme. I updated this repository also as work as an example usage for VS Code extension. If user opened this repository, VS Code recommends to use Marp extension.

User can use custom theme CSS by changing `theme` global directive to `example`.

```markdown
---
marp: true
theme: example
---

...
```
