### PR TITLE
Support GitHub Pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Deploy to GitHub pages
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: dist

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - github-pages
 
 jobs:
   build:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -21,15 +21,28 @@ jobs:
         with:
           node-version: '^12.13.1'
 
-      - name: Build Marp slide deck
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies and Puppeteer
         run: |
           npm ci
           npm i puppeteer --no-save
+
+      - name: Build Marp slide deck
+        run: |
           CHROME_PATH=$(node .puppeteer.js) npm run build
           touch ./dist/.nojekyll
         env:
           # Please update URL if you want to use custom domain
           URL: https://${{ github.event.repository.owner.name }}.github.io/${{ github.event.repository.name }}
+
+          # Recommend to set lang for your deck to get better rendering for Open Graph image 
+          LANG: en-US
 
       - name: Deploy to GitHub pages
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,38 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+      # For debug
+      - github-pages
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '^12.13.1'
+
+      - name: Build slide deck
+        run: |
+          npm ci
+          npm i puppeteer --no-save
+          CHROME_PATH=$(node .puppeteer.js) npm run build
+        env:
+          # Please update URL if you want to use custom domain
+          URL: https://${{ github.event.repository.owner.name }}.github.io/${{ github.event.repository.name }}
+
+      - name: Deploy to GitHub pages
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: dist

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - github-pages
 
 jobs:
   build:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
 
-      # For debug
-      - github-pages
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -41,7 +38,7 @@ jobs:
           # Please update URL if you want to use custom domain
           URL: https://${{ github.event.repository.owner.name }}.github.io/${{ github.event.repository.name }}
 
-          # Recommend to set lang for your deck to get better rendering for Open Graph image 
+          # Recommend to set lang for your deck to get better rendering for Open Graph image
           LANG: en-US
 
       - name: Deploy to GitHub pages

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -21,11 +21,12 @@ jobs:
         with:
           node-version: '^12.13.1'
 
-      - name: Build slide deck
+      - name: Build Marp slide deck
         run: |
           npm ci
           npm i puppeteer --no-save
           CHROME_PATH=$(node .puppeteer.js) npm run build
+          touch ./dist/.nojekyll
         env:
           # Please update URL if you want to use custom domain
           URL: https://${{ github.event.repository.owner.name }}.github.io/${{ github.event.repository.name }}

--- a/PITCHME.md
+++ b/PITCHME.md
@@ -40,7 +40,7 @@ https://github.com/yhatt/marp-cli-example
 
 [![Fork on GitHub h:1.5em](https://img.shields.io/github/forks/yhatt/marp-cli-example?label=Fork&style=social)](https://github.com/yhatt/marp-cli-example)
 
-<!-- _footer: Powered by GitHub Actions -->
+<!-- _footer: ":information_source: Require to pass ACCESS_TOKEN as secret." -->
 
 ---
 

--- a/PITCHME.md
+++ b/PITCHME.md
@@ -26,9 +26,21 @@ https://github.com/yhatt/marp-cli-example
 ![bg](#123)
 ![](#fff)
 
-##### <!--fit--> [@marp-team/marp-cli](https://github.com/marp-team/marp-cli) + [Netlify](https://www.netlify.com/) | [Now](https://zeit.co/now)
+##### <!--fit--> [Marp CLI](https://github.com/marp-team/marp-cli) + [GitHub Pages](https://github.com/pages) | [Netlify](https://www.netlify.com/) | [ZEIT Now](https://zeit.co/now)
 
 ##### <!--fit--> 👉 The easiest way to host<br />your Marp deck on the web
+
+---
+
+![bg right 70%](https://icongr.am/octicons/mark-github.svg)
+
+## **[GitHub Pages](https://github.com/pages)**
+
+#### Ready to write & host your deck!
+
+[![Fork on GitHub h:1.5em](https://img.shields.io/github/forks/yhatt/marp-cli-example?label=Fork&style=social)](https://github.com/yhatt/marp-cli-example)
+
+<!-- _footer: Powered by GitHub Actions -->
 
 ---
 
@@ -38,19 +50,17 @@ https://github.com/yhatt/marp-cli-example
 
 #### Ready to write & host your deck!
 
-[![Deploy to Netlify w:300](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/yhatt/marp-cli-example)
+[![Deploy to Netlify h:1.5em](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/yhatt/marp-cli-example)
 
 ---
 
 ![bg right 70%](https://assets.zeit.co/image/upload/front/assets/design/now-black.svg)
 
-## **[Now](https://zeit.co/now)**
+## **[ZEIT Now](https://zeit.co/now)**
 
-#### Host your deck by just running `now`!
+#### Ready to write & host your deck!
 
-```bash
-now
-```
+[![Deploy with ZEIT Now h:1.5em](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/yhatt/marp-cli-example)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ We have [GitHub Actions workflow](.github/workflows/github-pages.yml) to build a
 
 > :warning: Please notice the slide deck hosted with GitHub Pages will be made public even if you forked this to private repository.
 
+#### Setup personal access token
+
+In the moment, deploying from public repository to GitHub Pages requires setting up your access token as secret. ([Track discussion in forum...](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/26869/highlight/true))
+
+1. Go to **["Personal Access Tokens"](https://github.com/settings/tokens)** setting page and click **"Generate New Token"**.
+2. Create new token with **"repo"** scope, and _copy generated token_.
+3. Go to **"Settings"** tab in _forked repository_, and select **"Secrets"** from sidebar.
+4. Add a new secret **"ACCESS_TOKEN"** with the value of generated token.
+5. Try to update `master` branch.
+
 ### <img src="https://www.netlify.com/img/press/logos/logomark.svg" width="24" height="24" valign="bottom" /> [Netlify]
 
 Push **"Deploy to netlify"** button. [Netlify] will create your repository based on this example and host website from `master` branch automatically.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## See published slide deck
 
-- <img src="http://github.com/favicon.ico" width="24" height="24" valign="bottom" /> **[GitHub Pages]**: https://yhatt.github.io/marp-cli-example
+- <img src="https://icongr.am/octicons/mark-github.svg" width="24" height="24" valign="bottom" /> **[GitHub Pages]**: https://yhatt.github.io/marp-cli-example
 - <img src="https://www.netlify.com/img/press/logos/logomark.svg" width="24" height="24" valign="bottom" /> **[Netlify]**: https://yhatt-marp-cli-example.netlify.com/
 - <img src="https://assets.zeit.co/image/upload/front/assets/design/now-black.svg" width="24" height="24" valign="bottom" /> **[ZEIT Now][now]**: https://marp-cli-example.yhatt.now.sh/
 
@@ -26,11 +26,13 @@
 
 It's surprisingly easy to start publishing your slide deck!
 
-### <img src="http://github.com/favicon.ico" width="24" height="24" valign="bottom" /> [GitHub Pages]
+### <img src="https://icongr.am/octicons/mark-github.svg" width="24" height="24" valign="bottom" /> [GitHub Pages]
 
 [Just fork this repository](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) from **"Fork"** button in right-top corner!
 
 We have [GitHub Actions workflow](.github/workflows/github-pages.yml) to build and deploy from `master` to `gh-pages` automatically. Marp slide deck generated from [`PITCHME.md`](PITCHME.md) will be published to `https://<your-name>.github.io/<repository-name>`.
+
+> :warning: Please notice the slide deck hosted with GitHub Pages will be made public even if you forked this to private repository.
 
 ### <img src="https://www.netlify.com/img/press/logos/logomark.svg" width="24" height="24" valign="bottom" /> [Netlify]
 

--- a/README.md
+++ b/README.md
@@ -4,94 +4,82 @@
 
 - Write your slide deck by [Marp] Markdown.
 - Manage the content of slides via Git. (Using [GitPitch](https://gitpitch.com/) style `PITCHME.md`)
-- Host your deck at GitHub, and publish as webpage with [Netlify] / [Now]!
+- Host your deck at GitHub, and publish as webpage with [GitHub Pages], [Netlify], and [ZEIT Now][now]!
 
 [marp]: https://marp.app/
 [marp cli]: https://github.com/marp-team/marp-cli
+[github pages]: https://pages.github.com/
 [netlify]: https://www.netlify.com/
 [now]: https://zeit.co/now
 
 <p align="center">
-  <a href="https://yhatt-marp-cli-example.netlify.com/"><img src="https://yhatt-marp-cli-example.netlify.com/og-image.jpg" width="500" /></a>
+  <a href="https://yhatt.github.io/marp-cli-example"><img src="https://yhatt.github.io/marp-cli-example/og-image.jpg" width="500" /></a>
 </p>
 
-## See published slide
+## See published slide deck
 
+- <img src="http://github.com/favicon.ico" width="24" height="24" valign="bottom" /> **[GitHub Pages]**: https://yhatt.github.io/marp-cli-example
 - <img src="https://www.netlify.com/img/press/logos/logomark.svg" width="24" height="24" valign="bottom" /> **[Netlify]**: https://yhatt-marp-cli-example.netlify.com/
-- <img src="https://assets.zeit.co/image/upload/front/assets/design/now-black.svg" width="24" height="24" valign="bottom" /> **[Now]**: https://marp-cli-example.yhatt.now.sh/
+- <img src="https://assets.zeit.co/image/upload/front/assets/design/now-black.svg" width="24" height="24" valign="bottom" /> **[ZEIT Now][now]**: https://marp-cli-example.yhatt.now.sh/
 
 ## Usage
 
-It's surprisingly easy to start writing your slide deck!
+It's surprisingly easy to start publishing your slide deck!
+
+### <img src="http://github.com/favicon.ico" width="24" height="24" valign="bottom" /> [GitHub Pages]
+
+[Just fork this repository](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) from **"Fork"** button in right-top corner!
+
+We have [GitHub Actions workflow](.github/workflows/github-pages.yml) to build and deploy from `master` to `gh-pages` automatically. Marp slide deck generated from [`PITCHME.md`](PITCHME.md) will be published to `https://<your-name>.github.io/<repository-name>`.
 
 ### <img src="https://www.netlify.com/img/press/logos/logomark.svg" width="24" height="24" valign="bottom" /> [Netlify]
 
-Push **"Deploy to netlify"** button. [Netlify] will create your repository based on this example and host website automatically.
+Push **"Deploy to netlify"** button. [Netlify] will create your repository based on this example and host website from `master` branch automatically.
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/yhatt/marp-cli-example)
 
-After than, clone _your repository_ and install Marp CLI. (Required [Node.js](https://nodejs.org/) >= 8)
+### <img src="https://assets.zeit.co/image/upload/front/assets/design/now-black.svg" width="24" height="24" valign="bottom" /> [ZEIT Now][now]
 
-```bash
-git clone https://github.com/[your-name]/[repository-name].git
-cd ./[repository-name]
+Push **"Deploy"** button. [ZEIT Now][now] can choose to create your repository into GitHub / GitLab based on this example, or just to try publishing slide deck in your without fork.
 
-npm install
-```
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/yhatt/marp-cli-example)
 
-OK, ready to write your slide deck! Edit **`PITCHME.md`** with your favorite editor, and preview with `npm run start`. By pushing Git commit to `master`, Netlify will host the deck to website.
-
-> :information_source: Netlify integration can make an [Open Graph](http://ogp.me/) image automatically.
-
-### <img src="https://assets.zeit.co/image/upload/front/assets/design/now-black.svg" width="24" height="24" valign="bottom" /> [Now]
-
-You can try publishing deck by using [Now] without a forked repository. After than [install and setup Now](https://zeit.co/docs/v2/getting-started/installation/), clone this repository and just run `now`.
-
-```bash
-git clone https://github.com/yhatt/marp-cli-example.git
-cd ./marp-cli-example
-
-now
-```
-
-An example slide will publish to **`https://marp-cli-example.[your-name].now.sh`**. When you made a satisfied deck by editing `PITCHME.md`, publish to your favorite and friendly URL by `now alias`.
-
-```bash
-# Alias to https://friendly-subdomain.now.sh
-now alias https://marp-cli-example.[your-name].now.sh friendly-subdomain
-
-# Alias to your custom domain registered to Now
-now alias https://marp-cli-example.[your-name].now.sh your-custom-domain.com
-```
-
-Of course, you can manage deck via Git / GitHub at a forked repository. As same as Netlify, [Now GitHub integration](https://zeit.co/github) allows publishing `master` branch automatically.
+> :information_source: The auto-generated open graph image is not available in deployment through ZEIT Now.
 
 ## How to write
 
-Please see the documentation of [Marpit Markdown](https://marpit.marp.app/markdown), [the features of Marp Core](https://github.com/marp-team/marp-core#features), and the default example in [`PITCHME.md`](https://raw.githubusercontent.com/yhatt/marp-cli-example/master/PITCHME.md).
+For Marp slide deck features, please see the documentation of [Marpit Markdown](https://marpit.marp.app/markdown), [the features of Marp Core](https://github.com/marp-team/marp-core#features), and the default example in [`PITCHME.md`](https://raw.githubusercontent.com/yhatt/marp-cli-example/master/PITCHME.md) for .
+
+You have to install [Node.js](https://nodejs.org/) and run `npm i` at first if you want to write slide deck with [Marp CLI].
+
+### Edit deck
+
+Just edit **[`PITCHME.md`](./PITCHME.md)**!
+
+#### Preview deck
 
 [**Marp for VS Code**](https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode) extension is the best partner for writing Marp slide deck with live preview.
 
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode">
-    <img src="https://raw.githubusercontent.com/marp-team/marp-vscode/master/images/screenshot.png" width="500" />
+    <img src="https://raw.githubusercontent.com/marp-team/marp-vscode/master/docs/screenshot.png" width="500" />
   </a>
 </p>
+
+#### Preview via CLI
+
+```bash
+npm run start
+```
+
+It will be opened preview window via installed Google Chrome, and track change of `PITCHME.md`.
 
 ### Assets and themes
 
 - `assets` directory can put your assets for using in the deck. (e.g. Image resources)
 - `themes` directory can put [custom theme CSS](https://marpit.marp.app/theme-css). To use in the deck, please change `theme` global directive.
 
-### Preview deck
-
-```bash
-npm run start
-```
-
-It will be opened preview window via Chrome, and track change of `PITCHME.md`.
-
-### Build deck
+### Build deck via CLI
 
 ```bash
 npm run build

--- a/README.md
+++ b/README.md
@@ -28,21 +28,23 @@ It's surprisingly easy to start publishing your slide deck!
 
 ### <img src="https://icongr.am/octicons/mark-github.svg" width="24" height="24" valign="bottom" /> [GitHub Pages]
 
-[Just fork this repository](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) from **"Fork"** button in right-top corner!
+[Fork this repository](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) from **"Fork"** button in right-top corner to start!
 
-We have [GitHub Actions workflow](.github/workflows/github-pages.yml) to build and deploy from `master` to `gh-pages` automatically. Marp slide deck generated from [`PITCHME.md`](PITCHME.md) will be published to `https://<your-name>.github.io/<repository-name>`.
+#### Setup GitHub Actions
 
-> :warning: Please notice the slide deck hosted with GitHub Pages will be made public even if you forked this to private repository.
-
-#### Setup personal access token
+We have [GitHub Actions workflow](.github/workflows/github-pages.yml) to build and deploy from `master` to `gh-pages` automatically.
 
 In the moment, deploying from public repository to GitHub Pages requires setting up your access token as secret. ([Track discussion in forum...](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/26869/highlight/true))
 
 1. Go to **["Personal Access Tokens"](https://github.com/settings/tokens)** setting page and click **"Generate New Token"**.
 2. Create new token with **"repo"** scope, and _copy generated token_.
-3. Go to **"Settings"** tab in _forked repository_, and select **"Secrets"** from sidebar.
+3. Go to **"Settings"** tab in forked repository, and select **"Secrets"** from sidebar.
 4. Add a new secret **"ACCESS_TOKEN"** with the value of generated token.
-5. Try to update `master` branch.
+5. Turn on GitHub Actions in forked repository from **"Actions"** tab.
+
+Marp slide deck generated from [`PITCHME.md`](PITCHME.md) will be published to `https://<your-name>.github.io/<repository-name>`.
+
+> :warning: Please notice the slide deck hosted with GitHub Pages will be made public even if you forked this to private repository.
 
 ### <img src="https://www.netlify.com/img/press/logos/logomark.svg" width="24" height="24" valign="bottom" /> [Netlify]
 


### PR DESCRIPTION
Now we can deploy generated Marp slide deck to GitHub Pages powered via generally available GitHub Actions!

I added a workflow file to push static HTML file and assets into `gh-pages` branch. To host simple Marp deck, third-party services are no longer required. Just fork repository, setup `ACCESS_TOKEN` secret and edit `PITCHME.md`.