### PR TITLE
Update GitHub Actions for deploying to GitHub pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,29 +3,32 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - master
+      - $default-branch
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
-      - name: Detect Node version from .nvmrc
-        id: node_version
-        run: echo "::set-output name=nvmrc::$(cat .nvmrc)"
-
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.node_version.outputs.nvmrc }}
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies and Puppeteer
         run: |
@@ -34,9 +37,7 @@ jobs:
           npm i puppeteer --no-save
 
       - name: Build Marp slide deck
-        run: |
-          CHROME_PATH=$(node -e "console.log(require('puppeteer').executablePath())") npm run build
-          touch ./public/.nojekyll
+        run: CHROME_PATH=$(node -e "console.log(require('puppeteer').executablePath())") npm run build
         env:
           # Please update URL if you want to use custom domain
           URL: https://${{ github.event.repository.owner.name }}.github.io/${{ github.event.repository.name }}
@@ -44,10 +45,11 @@ jobs:
           # Recommend to set lang for your deck to get better rendering for Open Graph image
           LANG: en-US
 
-      - name: Deploy to GitHub pages
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+      - name: Upload page artifacts
+        uses: actions/upload-pages-artifact@v1
         with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: public
+          path: public
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@main


### PR DESCRIPTION
https://github.blog/changelog/2022-08-10-github-pages-builds-with-github-actions-ga/
Building GitHub Pages through GitHub Actions is generally available. This PR changes to use `actions/deploy-pages` action to deploy into GitHub Pages.